### PR TITLE
Update CDN link to widget

### DIFF
--- a/index.js
+++ b/index.js
@@ -28,7 +28,7 @@ AFRAME.registerSystem('uploadcare', {
 
   init: function () {
     window.UPLOADCARE_PUBLIC_KEY = this.data.publicKey;
-    injectJS('https://ucarecdn.com/widget/2.10.0/uploadcare/uploadcare.full.min.js');
+    injectJS('https://ucarecdn.com/libs/widget/2.x/uploadcare.full.min.js');
   },
 
   upload: function (value, contentType) {


### PR DESCRIPTION
Hi @fernandojsg! Thank you for the awesome component!

Uploadcare CDN has special wildcard links allowing to get the latest minor/patch version of the major 2 (`2.x`). This might help you to always work with the most relevant version. Btw, currently the latest version is `2.10.3`, see our [changelog](https://github.com/uploadcare/uploadcare-widget/blob/master/HISTORY.markdown).